### PR TITLE
Removed duplicated albums from Top Albums 

### DIFF
--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -103,13 +103,13 @@ function insertAlbumArtByTopArtists(context) {
 		var tracks = toJSArray(res.items);
 		
 		// Create a new array filled with the tracks album name & artwork
-		var albums = tracks.map(item => { 
+		var albums = tracks.map(function(item) { 
 			return { name: item.track.album.name.UTF8String(), artworkUrl: item.track.album.images[0].url.UTF8String() }
 		});
 
 		// Filter out duplicate albums by their name
 		var albumNames = [];
-		var uniqueAlbums = albums.filter(album => {
+		var uniqueAlbums = albums.filter(function(album) {
 			if (albumNames.indexOf(album.name) < 0) {
 				albumNames.push(album.name);
 				return true;

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -102,10 +102,6 @@ function insertAlbumArtByTopArtists(context) {
 	spotifyAPI(endpoint, function(res) {
 		
 		var tracks = toJSArray(res.items);
-		var numTracks = tracks.length;
-		var max = selection.length;
-			
-		if (max > numTracks) { max = numTracks }
 		
 		// Create a new array filled with the tracks album name & artwork
 		var albums = tracks.map(item => { 

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -101,14 +101,14 @@ function insertAlbumArtByTopArtists(context) {
 	
 	spotifyAPI(endpoint, function(res) {
 		
-		var tracks = res.items;
+		var tracks = toJSArray(res.items);
 		var numTracks = tracks.length;
 		var max = selection.length;
 			
 		if (max > numTracks) { max = numTracks }
 		
 		// Randomize
-		tracks = toJSArray(tracks).sort(function(a, b) {
+		tracks = tracks.sort(function(a, b) {
 			return 0.5 - Math.random();
 		});
 		

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -123,16 +123,21 @@ function insertAlbumArtByTopArtists(context) {
 		})
 		
 		// Randomize
-		tracks = tracks.sort(function(a, b) {
+		uniqueAlbums = uniqueAlbums.sort(function(a, b) {
 			return 0.5 - Math.random();
 		});
 		
-		// Loop through slection and set pattern fills
-		for (var i = 0; i < max; i++) {
-			ajax(tracks[i].track.album.images[0].url, function(imageData) {	
+		 // Loop through selection and set pattern fills
+		 // If the selection length is greater than the albums length, fill the albums again from the start.
+		 for (var i = 0, albumIndex = 0; i < selection.length; i++, albumIndex++) {
+			if (albumIndex === uniqueAlbums.length - 1) {
+				albumIndex = 0;
+			}
+
+			ajax(uniqueAlbums[albumIndex].artwork, function(imageData) {	
 				setImage(selection[i], imageData);
 			});
-		}	
+		}
 	
 	});
 	

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -100,7 +100,6 @@ function insertAlbumArtByTopArtists(context) {
 	var endpoint = "/v1/users/spotifycharts/playlists/37i9dQZEVXbLRQDuF5jeBp/tracks";
 	
 	spotifyAPI(endpoint, function(res) {
-		
 		var tracks = toJSArray(res.items);
 		
 		// Create a new array filled with the tracks album name & artwork
@@ -123,9 +122,9 @@ function insertAlbumArtByTopArtists(context) {
 			return 0.5 - Math.random();
 		});
 		
-		 // Loop through selection and set pattern fills
-		 // If the selection length is greater than the albums length, fill the albums again from the start.
-		 for (var i = 0, albumIndex = 0; i < selection.length; i++, albumIndex++) {
+		// Loop through selection and set pattern fills
+		// If the selection length is greater than the albums length, fill the albums again from the start.
+		for (var i = 0, albumIndex = 0; i < selection.length; i++, albumIndex++) {
 			if (albumIndex === uniqueAlbums.length - 1) {
 				albumIndex = 0;
 			}
@@ -134,9 +133,7 @@ function insertAlbumArtByTopArtists(context) {
 				setImage(selection[i], imageData);
 			});
 		}
-	
 	});
-	
 }
 
 

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -104,7 +104,7 @@ function insertAlbumArtByTopArtists(context) {
 		
 		// Create a new array filled with the tracks album name & artwork
 		var albums = tracks.map(item => { 
-			return { name: item.track.album.name.UTF8String(), artwork: item.track.album.images[0].url.UTF8String() }
+			return { name: item.track.album.name.UTF8String(), artworkUrl: item.track.album.images[0].url.UTF8String() }
 		});
 
 		// Filter out duplicate albums by their name
@@ -129,7 +129,7 @@ function insertAlbumArtByTopArtists(context) {
 				albumIndex = 0;
 			}
 
-			ajax(uniqueAlbums[albumIndex].artwork, function(imageData) {	
+			ajax(uniqueAlbums[albumIndex].artworkUrl, function(imageData) {	
 				setImage(selection[i], imageData);
 			});
 		}

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -111,6 +111,16 @@ function insertAlbumArtByTopArtists(context) {
 		var albums = tracks.map(item => { 
 			return { name: item.track.album.name.UTF8String(), artwork: item.track.album.images[0].url.UTF8String() }
 		});
+
+		// Filter out duplicate albums by their name
+		var albumNames = [];
+		var uniqueAlbums = albums.filter(album => {
+			if (albumNames.indexOf(album.name) < 0) {
+				albumNames.push(album.name);
+				return true;
+			}
+			return false;
+		})
 		
 		// Randomize
 		tracks = tracks.sort(function(a, b) {

--- a/Spotify.sketchplugin/Contents/Sketch/main.js
+++ b/Spotify.sketchplugin/Contents/Sketch/main.js
@@ -107,6 +107,11 @@ function insertAlbumArtByTopArtists(context) {
 			
 		if (max > numTracks) { max = numTracks }
 		
+		// Create a new array filled with the tracks album name & artwork
+		var albums = tracks.map(item => { 
+			return { name: item.track.album.name.UTF8String(), artwork: item.track.album.images[0].url.UTF8String() }
+		});
+		
 		// Randomize
 		tracks = tracks.sort(function(a, b) {
 			return 0.5 - Math.random();


### PR DESCRIPTION
Resolves #1.

Like suggested, I filtered the albums by their name instead of their artwork URL, and also handled cases where the selection number is greater than the albums number.